### PR TITLE
s3gw: add docs links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM opensuse/tumbleweed as opensuse/jekyll
+
+ENV LC_ALL C.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+RUN zypper --non-interactive install -t pattern \
+      devel_ruby \
+      devel_C_C++ \
+ && zypper --non-interactive install \
+      ruby-devel \
+ && zypper clean --all \
+ && gem install \
+      jekyll \
+      bundler \
+ && mkdir -p /jekyllapp
+
+WORKDIR /jekyllapp
+
+FROM opensuse/jekyll
+
+COPY . /jekyllapp
+RUN bundle install
+EXPOSE 4000
+
+CMD [ "bundle", "exec", "jekyll", "serve", "--host=0.0.0.0" ]

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '~> 3.9.2'
+gem 'webrick', '~> 1.7.0'
 
 group :jekyll_plugins do
   gem 'jekyll-archives', '~> 2.2.1'

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,10 +1,10 @@
 - links:
-  - name: s3gw core
-    link: https://github.com/aquarist-labs/s3gw-core
+  - name: s3gw
+    link: https://github.com/aquarist-labs/s3gw
     new_window: false
 
 - links:
-  - name: s3gw charts
+  - name: s3gw Helm chart
     link: https://github.com/aquarist-labs/s3gw-charts
     new_window: false
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,7 +2,15 @@
   link: /s3gw/
   new_window: false
   highlight: false
+- name: Documentation
+  link: https://s3gw-docs.readthedocs.io/en/latest
+  new_window: false
+  highlight: false
+- name: Helm Chart
+  link: https://artifacthub.io/packages/helm/s3gw/s3gw
+  new_window: false
+  highlight: false
 - name: Github
-  link: https://github.com/aquarist-labs
+  link: https://github.com/aquarist-labs/s3gw
   new_window: true
   highlight: false

--- a/_sass/landing-page.scss
+++ b/_sass/landing-page.scss
@@ -15,6 +15,19 @@
 }
 
 
+.top-cta {
+	background: linear-gradient(to bottom, $brand-color 0%, $middle-gradient-color 100%);
+	color: #fff;
+	text-align: center;
+	margin: 0;
+	padding: 50px 0;
+
+	.button {
+		display: inline-block;
+	}
+}
+
+
 .hero {
 	color: #fff;
 	text-align: center;

--- a/s3gw.html
+++ b/s3gw.html
@@ -6,7 +6,11 @@ description: S3-compatible gateway for on-premise k8s storage
 	<div class="text-container">
 		<h1> <img src="{{ site.baseurl }}/images/s3gw-logo.svg" alt="Screenshot" class="s3gw-logo" /><strong>s3gw</strong></h1>
 		<p class="subtext ">s3gw is an easy-to-use Open Source and Cloud Native S3 service for use on Kubernetes</p>
-		<div class="cta button alt"><a href="https://github.com/aquarist-labs/s3gw-core#quickstart">Quickstart guide</a></div>
+
+    <div class="top-cta">
+		<div class="button alt"><a href="https://github.com/aquarist-labs/s3gw#quickstart">Quickstart guide</a></div>
+		<div class="button alt"><a href="https://s3gw-docs.readthedocs.io/en/latest">Documentation</a></div>
+    </div>
 	</div>
 </section>
 
@@ -62,11 +66,15 @@ description: S3-compatible gateway for on-premise k8s storage
 	<section class="bottom-cta">
 		<h2>Easily deploy an <strong>S3 Gateway</strong> today</h2>
 		<div class="button">
-			<a href="https://github.com/aquarist-labs/s3gw-core#quickstart">Get Started</a>
+			<a href="https://github.com/aquarist-labs/s3gw#quickstart">Get Started</a>
 		</div>
 
 		<div class="button">
-			<a href="https://github.com/aquarist-labs/s3gw-core">Github</a>
+			<a href="https://s3gw-docs.readthedocs.io/en/latest">Documentation</a>
+		</div>
+
+		<div class="button">
+			<a href="https://github.com/aquarist-labs/s3gw">Github</a>
 		</div>
 	</section>
 </div>


### PR DESCRIPTION
- Add links to documentation, helm charts in various places.
- Update some links from the old s3gw-core repo to point to the new s3gw repo.
- Add Dockerfile for quick and easy development with batteries included.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>